### PR TITLE
Maks dagsats

### DIFF
--- a/src/main/kotlin/no/nav/helse/spenn/overforing/SendToOSTask.kt
+++ b/src/main/kotlin/no/nav/helse/spenn/overforing/SendToOSTask.kt
@@ -42,6 +42,7 @@ class SendToOSTask(val oppdragStateService: OppdragStateService,
                 utbetalingService.sendUtbetalingOppdragMQ(updated)
                 meterRegistry.counter(OPPDRAG, "status", OppdragStateStatus.SENDT_OS.name).increment()
             } else {
+                meterRegistry.counter(OPPDRAG, "status", "INSANE").increment()
                 log.error("oppdrag med soknadId=${it.soknadId} bestod ikke sanityCheck!")
             }
         }

--- a/src/main/kotlin/no/nav/helse/spenn/overforing/SendToOSTask.kt
+++ b/src/main/kotlin/no/nav/helse/spenn/overforing/SendToOSTask.kt
@@ -3,15 +3,17 @@ package no.nav.helse.spenn.overforing
 import io.micrometer.core.instrument.MeterRegistry
 import net.javacrumbs.shedlock.core.SchedulerLock
 import no.nav.helse.spenn.appsupport.OPPDRAG
+import no.nav.helse.spenn.oppdrag.AvstemmingDTO
+import no.nav.helse.spenn.oppdrag.OppdragStateDTO
 import no.nav.helse.spenn.oppdrag.dao.OppdragStateService
 import no.nav.helse.spenn.oppdrag.dao.OppdragStateStatus
-import no.nav.helse.spenn.oppdrag.AvstemmingDTO
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.math.BigDecimal
 
 
 @Component
@@ -28,16 +30,33 @@ class SendToOSTask(val oppdragStateService: OppdragStateService,
     @SchedulerLock(name = "sendToOS")
     fun sendToOS() {
         val oppdragList = oppdragStateService.fetchOppdragStateByStatus(OppdragStateStatus.SIMULERING_OK,limit)
+        if (oppdragList.size >= limit) {
+            log.warn("Det ble hentet ut ${oppdragList.size} oppdrag, som er maksGrensen, kanskje klarer vi ikke å få unna alle?")
+        }
         log.info("We are sending ${oppdragList.size} to OS")
 
         oppdragList.forEach {
-            val updated = it.copy(status = OppdragStateStatus.SENDT_OS, avstemming = AvstemmingDTO())
-            oppdragStateService.saveOppdragState(updated)
-            utbetalingService.sendUtbetalingOppdragMQ(updated)
-            meterRegistry.counter(OPPDRAG,"status", OppdragStateStatus.SENDT_OS.name).increment()
-
+            if (passesSanityCheck(it)) {
+                val updated = it.copy(status = OppdragStateStatus.SENDT_OS, avstemming = AvstemmingDTO())
+                oppdragStateService.saveOppdragState(updated)
+                utbetalingService.sendUtbetalingOppdragMQ(updated)
+                meterRegistry.counter(OPPDRAG, "status", OppdragStateStatus.SENDT_OS.name).increment()
+            } else {
+                log.error("oppdrag med soknadId=${it.soknadId} bestod ikke sanityCheck!")
+            }
         }
 
+    }
+
+    fun passesSanityCheck(oppdragDTO: OppdragStateDTO) : Boolean {
+        val maksDagsats = BigDecimal(99858 * 6.5 / 260) // TODO ?
+        oppdragDTO.utbetalingsOppdrag.utbetalingsLinje.forEach {
+            if (it.sats > maksDagsats) {
+                log.error("sats i oppdrag med soknadId=${oppdragDTO.soknadId} er ${it.sats} som er høyere enn begrensningen på $maksDagsats")
+                return false
+            }
+        }
+        return true
     }
 
 }

--- a/src/test/kotlin/no/nav/helse/spenn/overforing/SendToOSTaskSanityCheckTest.kt
+++ b/src/test/kotlin/no/nav/helse/spenn/overforing/SendToOSTaskSanityCheckTest.kt
@@ -1,0 +1,84 @@
+package no.nav.helse.spenn.overforing
+
+import io.micrometer.core.instrument.MockClock
+import io.micrometer.core.instrument.simple.SimpleConfig
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import no.nav.helse.spenn.any
+import no.nav.helse.spenn.oppdrag.*
+import no.nav.helse.spenn.oppdrag.dao.OppdragStateService
+import no.nav.helse.spenn.oppdrag.dao.OppdragStateStatus
+import no.nav.helse.spenn.vedtak.Vedtak
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.LocalDate
+import java.util.*
+
+class SendToOSTaskSanityCheckTest {
+
+    val maksDagsats = BigDecimal(99858 * 6.5 / 260)
+
+    @Test
+    fun dagssatsSomIkkeErOverMaksSkalIkkeBliStoppet() {
+        val mockUtbetalingService = mock(UtbetalingService::class.java)
+        val mockMeterRegistry = SimpleMeterRegistry(SimpleConfig.DEFAULT, MockClock())
+        val mockOppdragStateService = mock(OppdragStateService::class.java)
+
+        val ostask = SendToOSTask(mockOppdragStateService, mockUtbetalingService, mockMeterRegistry, 100)
+
+        val oppdrag = oppdragMedSats(maksDagsats.toLong())
+
+        `when`(mockOppdragStateService.fetchOppdragStateByStatus(OppdragStateStatus.SIMULERING_OK,100))
+                .thenReturn(listOf(oppdrag))
+
+        ostask.sendToOS()
+
+        verify(mockUtbetalingService).sendUtbetalingOppdragMQ(any())
+    }
+
+    @Test
+    fun dagsatsOverMaksSkalBliStoppet() {
+        val mockUtbetalingService = mock(UtbetalingService::class.java)
+        val mockMeterRegistry = SimpleMeterRegistry(SimpleConfig.DEFAULT, MockClock())
+        val mockOppdragStateService = mock(OppdragStateService::class.java)
+
+        val ostask = SendToOSTask(mockOppdragStateService, mockUtbetalingService, mockMeterRegistry, 100)
+
+        val oppdrag = oppdragMedSats(maksDagsats.toLong() + 1)
+
+        `when`(mockOppdragStateService.fetchOppdragStateByStatus(OppdragStateStatus.SIMULERING_OK,100))
+                .thenReturn(listOf(oppdrag))
+
+        ostask.sendToOS()
+
+        verify(mockUtbetalingService, never()).sendUtbetalingOppdragMQ(any())
+    }
+
+
+
+    private fun oppdragMedSats(sats: Long) =
+            OppdragStateDTO(
+                    soknadId = UUID.randomUUID(), utbetalingsOppdrag = UtbetalingsOppdrag(
+                    vedtak = Vedtak(
+                            soknadId = UUID.randomUUID(),
+                            maksDato = LocalDate.now().plusYears(1),
+                            vedtaksperioder = emptyList(),
+                            aktorId = "111122223333",
+                            saksbehandler = "SPA"
+                    ),
+                    oppdragGjelder = "12345678901",
+                    operasjon = AksjonsKode.OPPDATER,
+                    utbetalingsLinje = listOf(
+                            UtbetalingsLinje(id = "1",
+                                    satsTypeKode = SatsTypeKode.DAGLIG,
+                                    sats = BigDecimal.valueOf(sats),
+                                    utbetalesTil = "999888777",
+                                    datoFom = LocalDate.now().minusWeeks(4),
+                                    datoTom = LocalDate.now().minusWeeks(1),
+                                    grad = BigInteger.valueOf(100)
+                            )
+                    )
+            ))
+
+}


### PR DESCRIPTION
Endte etter litt grubling på å legge begrensningen i sendToOs-tasken, og om det kommer et oppdrag som bryter maksgrensen så stopper den ikke andre oppdrag, og det skal bli tatt med på neste task-kjøring etter en eventuell ny deploy med økt maksgrense.

La også inn en log.warn hvis utdrag fra DB når limit-antall, i tilfelle det skulle hope seg opp.

Sjekker ikke at satstype faktisk er Dagsats, så skal man støtte noe annet så må det gjøres noe der.